### PR TITLE
`TOKEN_FILE` location and whitespace

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,7 +127,7 @@ async function getToken() {
   }
 
   if (fs.existsSync(TOKEN_FILE)) {
-    config.token = fs.readFileSync(TOKEN_FILE, "utf-8");
+    config.token = fs.readFileSync(TOKEN_FILE, "utf-8").trim();
     return;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export const config = {
 
 export const BASE_DIR = process.cwd();
 export const OUT_DIR = path.join(BASE_DIR, "slack-archive");
-export const TOKEN_FILE = path.join(BASE_DIR, ".token");
+export const TOKEN_FILE = path.join(OUT_DIR, ".token");
 export const DATA_DIR = path.join(OUT_DIR, "data");
 export const HTML_DIR = path.join(OUT_DIR, "html");
 export const FILES_DIR = path.join(HTML_DIR, "files");

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export const config = {
 
 export const BASE_DIR = process.cwd();
 export const OUT_DIR = path.join(BASE_DIR, "slack-archive");
-export const TOKEN_FILE = path.join(OUT_DIR, ".token");
+export const TOKEN_FILE = path.join(BASE_DIR, ".token");
 export const DATA_DIR = path.join(OUT_DIR, "data");
 export const HTML_DIR = path.join(OUT_DIR, "html");
 export const FILES_DIR = path.join(HTML_DIR, "files");


### PR DESCRIPTION
If the `OUT_DIR` is used as a docroot, it’s a good idea to put the `TOKEN_FILE` outside this.

Also, if the file contains a trailing newline, this causes the authorisation to fail.