### PR TITLE
make npm scripts work

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,5 +97,9 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "ts-node": {
+    "esm": true,
+    "transpileOnly": true
+  },
 }


### PR DESCRIPTION
trying to run `npm run cli` and other scripts currently throw errors 

ts-node seems to be need to be told to run in esm mode

had to add transpileOnly as well because otherwise it complains about missing types for esm modules

resolves https://github.com/felixrieseberg/slack-archive/issues/9