### PR TITLE
Fix file downloads

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,8 +213,6 @@ export async function main() {
     newMessages[channel.id] = downloadData.new;
     await downloadExtras(channel, result, users);
 
-    // Download files
-    await downloadFilesForChannel(channel.id!);
     await downloadAvatars();
 
     // Sort messages
@@ -232,6 +230,9 @@ export async function main() {
       getChannelDataFilePath(channel.id),
       JSON.stringify(result, undefined, 2)
     );
+
+    // Download files. This needs to run after the messages are saved to disk since it uses the message data to find which files to download.
+    await downloadFilesForChannel(channel.id!);
 
     // Update the data load cache
     messagesCache[channel.id!] = result;


### PR DESCRIPTION
Fixes https://github.com/felixrieseberg/slack-archive/issues/12

`downloadFilesForChannel` relies on data downloaded by `downloadMessages` being persisted to disk, but was running before the file were written and was getting no files. This PR moves the `downloadFilesForChannel` call to after the data files are written

An alternative would have been to import `messagesCache` in download-messages, set the cache after paginating through conversation history, and tell downloadFilesForChannel's `getMessages` to use the cache, but that feels a bit messier