### PR TITLE
Suport for running in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+slack-archive_USERDATA
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:16
+
+WORKDIR /slack-archive
+
+COPY *.json ./
+COPY yarn.lock ./
+RUN npm install
+
+# NOTE: see also .dockerignore
+COPY . /slack-archive/
+
+RUN npm run compile
+
+VOLUME /slack-archive/slack-archive
+ENTRYPOINT ["bin/slack-archive.js"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ can still enjoy in 20 years. This tool will help you do that.
 npx slack-archive
 ```
 
+Alternatively, to run a development version in Docker:
+1. Checkout the code from Git
+2. Make sure Docker is installed
+3. Run `./run_in_docker.sh`
+
+This will build Docker image called `slack-archive:dev`, compile it and start the interactive guide.
+Results wil be saved in folder `slack-archive_USERDATA/`.
+
 ### Parameters
 
 ```

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p slack-archive_USERDATA
+docker build -t slack-archive:dev .
+docker run --mount type=bind,source="$(pwd)"/slack-archive_USERDATA,target=/slack-archive/slack-archive -it slack-archive:dev


### PR DESCRIPTION
Here's a Dockerfile and a script that allow running current Github version of the app in a temporary Linux image.
The script...
```
$ ./run_in_docker.sh
```
...build a Docker image, compiles the typescript and runs the CLI, that then asks for Slack token.
Results will be saved in `slack-archive_USERDATA` folder.