### PR TITLE
Feat: Add --channel-types cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ npx slack-archive
 ```
 --automatic:                Don't prompt and automatically fetch all messages from all channels.
 --channel-types             Comma-separated list of channel types to fetch messages from.
+                            (public_channel, private_channel, mpim, im)
 --no-backup:                Don't create backups. Not recommended.
 --no-search:                Don't create a search file, saving disk space.
---no-file-download:          Don't download files.
+--no-file-download:         Don't download files.
 --no-slack-connect:         Don't connect to Slack, just generate HTML from local data.
 --force-html-generation:    Force regeneration of HTML files. Useful after slack-archive upgrades.
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npx slack-archive
 
 ```
 --automatic:                Don't prompt and automatically fetch all messages from all channels.
+--channel-types             Comma-separated list of channel types to fetch messages from.
 --no-backup:                Don't create backups. Not recommended.
 --no-search:                Don't create a search file, saving disk space.
 --no-file-download:          Don't download files.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   config,
   TOKEN_FILE,
   AUTOMATIC_MODE,
+  CHANNEL_TYPES,
   DATE_FILE,
   EMOJIS_DATA_PATH,
   NO_SLACK_CONNECT,
@@ -109,6 +110,10 @@ async function selectChannelTypes(): Promise<Array<string>> {
       value: "im",
     },
   ];
+
+  if (CHANNEL_TYPES) {
+    return CHANNEL_TYPES.split(',');
+  }
 
   if (AUTOMATIC_MODE || NO_SLACK_CONNECT) {
     return ["public_channel", "private_channel", "mpim", "im"];

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,20 @@ function findCliParameter(param: string) {
   return false;
 }
 
+function getCliParameter(param: string) {
+  const args = process.argv;
+
+  for (const [i, arg] of args.entries()) {
+    if (arg === param) {
+      return args[i + 1];
+    }
+  }
+
+  return null;
+}
+
 export const AUTOMATIC_MODE = findCliParameter("--automatic");
+export const CHANNEL_TYPES = getCliParameter("--channel-types");
 export const NO_BACKUP = findCliParameter("--no-backup");
 export const NO_SEARCH = findCliParameter("--no-search");
 export const NO_FILE_DOWNLOAD = findCliParameter("--no-file-download");


### PR DESCRIPTION
This adds an extra cli argument `--channel-types` which allows to specify which channel types to download messages from, thus bypassing the prompt dialog.

Example of usage:
```bash
yarn cli --automatic --channel-types public_channel,private_channel
```