### PR TITLE
 Feat: use-previous-channel-config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npx slack-archive
 
 ```
 --automatic:                Don't prompt and automatically fetch all messages from all channels.
+--use-previous-channel-config: Fetch messages from channels selected in previous run instead of prompting.
 --channel-types             Comma-separated list of channel types to fetch messages from.
                             (public_channel, private_channel, mpim, im)
 --no-backup:                Don't create backups. Not recommended.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   config,
   TOKEN_FILE,
   AUTOMATIC_MODE,
+  USE_PREVIOUS_CHANNEL_CONFIG,
   CHANNEL_TYPES,
   DATE_FILE,
   EMOJIS_DATA_PATH,
@@ -35,6 +36,7 @@ import { downloadEmojiList, downloadEmojis } from "./emoji.js";
 import { downloadAvatars } from "./users.js";
 import { downloadChannels } from "./channels.js";
 import { authTest } from "./web-client.js";
+import { SlackArchiveChannelData } from "./interfaces.js";
 
 const { prompt } = inquirer;
 
@@ -67,8 +69,32 @@ async function selectMergeFiles(): Promise<boolean> {
 }
 
 async function selectChannels(
-  channels: Array<Channel>
+  channels: Array<Channel>,
+  previouslyDownloadedChannels: Record<string, SlackArchiveChannelData>,
 ): Promise<Array<Channel>> {
+    
+  if (USE_PREVIOUS_CHANNEL_CONFIG) {
+      const selectedChannels: Array<Channel> = channels.filter((channel) => channel.id && channel.id in previouslyDownloadedChannels);
+      const selectedChannelNames = selectedChannels.map((channel) => channel.name || channel.id || "Unknown");
+      console.log(`Downloading channels selected previously: ${selectedChannelNames}.`);
+      
+      const previousChannelIds = Object.keys(previouslyDownloadedChannels);
+      if (previousChannelIds.length != selectedChannels.length) {
+        console.warn("WARNING: Did not find all previously selected channel IDs.")
+        console.log(`Expected to find ${previousChannelIds.length} channels, but only ${selectedChannels.length} matched.`);
+        // Consider Looking up the user-facing names of the missing channels in the saved data.
+        const availableChannelIds = new Set<string>(channels.map((channel) => channel.id || ""));
+        const missingChannelIds = previousChannelIds.filter((cId) => !(availableChannelIds.has(cId)));
+        //console.log(availableChannelIds);
+        console.log(`Missing channel ids: ${missingChannelIds}`);
+        
+      } else {
+        console.log(`Matched all ${previousChannelIds.length} previously selected channels out of ${channels.length} total channels available.`);
+      }
+
+      return selectedChannels
+  } 
+    
   const choices = channels.map((channel) => ({
     name: channel.name || channel.id || "Unknown",
     value: channel,
@@ -115,7 +141,7 @@ async function selectChannelTypes(): Promise<Array<string>> {
     return CHANNEL_TYPES.split(',');
   }
 
-  if (AUTOMATIC_MODE || NO_SLACK_CONNECT) {
+  if (AUTOMATIC_MODE || USE_PREVIOUS_CHANNEL_CONFIG || NO_SLACK_CONNECT) {
     return ["public_channel", "private_channel", "mpim", "im"];
   }
 
@@ -238,7 +264,7 @@ export async function main() {
   slackArchiveData.auth = await getAuthTest();
 
   const channels = await downloadChannels({ types: channelTypes }, users);
-  const selectedChannels = await selectChannels(channels);
+  const selectedChannels = await selectChannels(channels, slackArchiveData.channels);
   const newMessages: Record<string, number> = {};
 
   // Emoji

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,31 +70,45 @@ async function selectMergeFiles(): Promise<boolean> {
 
 async function selectChannels(
   channels: Array<Channel>,
-  previouslyDownloadedChannels: Record<string, SlackArchiveChannelData>,
+  previouslyDownloadedChannels: Record<string, SlackArchiveChannelData>
 ): Promise<Array<Channel>> {
-    
   if (USE_PREVIOUS_CHANNEL_CONFIG) {
-      const selectedChannels: Array<Channel> = channels.filter((channel) => channel.id && channel.id in previouslyDownloadedChannels);
-      const selectedChannelNames = selectedChannels.map((channel) => channel.name || channel.id || "Unknown");
-      console.log(`Downloading channels selected previously: ${selectedChannelNames}.`);
-      
-      const previousChannelIds = Object.keys(previouslyDownloadedChannels);
-      if (previousChannelIds.length != selectedChannels.length) {
-        console.warn("WARNING: Did not find all previously selected channel IDs.")
-        console.log(`Expected to find ${previousChannelIds.length} channels, but only ${selectedChannels.length} matched.`);
-        // Consider Looking up the user-facing names of the missing channels in the saved data.
-        const availableChannelIds = new Set<string>(channels.map((channel) => channel.id || ""));
-        const missingChannelIds = previousChannelIds.filter((cId) => !(availableChannelIds.has(cId)));
-        //console.log(availableChannelIds);
-        console.log(`Missing channel ids: ${missingChannelIds}`);
-        
-      } else {
-        console.log(`Matched all ${previousChannelIds.length} previously selected channels out of ${channels.length} total channels available.`);
-      }
+    const selectedChannels: Array<Channel> = channels.filter(
+      (channel) => channel.id && channel.id in previouslyDownloadedChannels
+    );
+    const selectedChannelNames = selectedChannels.map(
+      (channel) => channel.name || channel.id || "Unknown"
+    );
+    console.log(
+      `Downloading channels selected previously: ${selectedChannelNames}.`
+    );
 
-      return selectedChannels
-  } 
-    
+    const previousChannelIds = Object.keys(previouslyDownloadedChannels);
+    if (previousChannelIds.length != selectedChannels.length) {
+      console.warn(
+        "WARNING: Did not find all previously selected channel IDs."
+      );
+      console.log(
+        `Expected to find ${previousChannelIds.length} channels, but only ${selectedChannels.length} matched.`
+      );
+      // Consider Looking up the user-facing names of the missing channels in the saved data.
+      const availableChannelIds = new Set<string>(
+        channels.map((channel) => channel.id || "")
+      );
+      const missingChannelIds = previousChannelIds.filter(
+        (cId) => !availableChannelIds.has(cId)
+      );
+      //console.log(availableChannelIds);
+      console.log(`Missing channel ids: ${missingChannelIds}`);
+    } else {
+      console.log(
+        `Matched all ${previousChannelIds.length} previously selected channels out of ${channels.length} total channels available.`
+      );
+    }
+
+    return selectedChannels;
+  }
+
   const choices = channels.map((channel) => ({
     name: channel.name || channel.id || "Unknown",
     value: channel,
@@ -138,7 +152,7 @@ async function selectChannelTypes(): Promise<Array<string>> {
   ];
 
   if (CHANNEL_TYPES) {
-    return CHANNEL_TYPES.split(',');
+    return CHANNEL_TYPES.split(",");
   }
 
   if (AUTOMATIC_MODE || USE_PREVIOUS_CHANNEL_CONFIG || NO_SLACK_CONNECT) {
@@ -264,7 +278,10 @@ export async function main() {
   slackArchiveData.auth = await getAuthTest();
 
   const channels = await downloadChannels({ types: channelTypes }, users);
-  const selectedChannels = await selectChannels(channels, slackArchiveData.channels);
+  const selectedChannels = await selectChannels(
+    channels,
+    slackArchiveData.channels
+  );
   const newMessages: Record<string, number> = {};
 
   // Emoji

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,9 @@ function getCliParameter(param: string) {
 }
 
 export const AUTOMATIC_MODE = findCliParameter("--automatic");
+export const USE_PREVIOUS_CHANNEL_CONFIG = findCliParameter(
+  "--use-previous-channel-config"
+);
 export const CHANNEL_TYPES = getCliParameter("--channel-types");
 export const NO_BACKUP = findCliParameter("--no-backup");
 export const NO_SEARCH = findCliParameter("--no-search");


### PR DESCRIPTION
New flag to use the channels selected in the previous run (stored in slack-archive.js) instead of prompting the user.

This allows the user to manually configure the channels once, then repeat the run in the future with the same configuration.

Note I see a similar PR right now for automatic with an 'exclude'; I could imagine a number of ways to automate this but this seemed like a relatively user-friendly mechanism.

